### PR TITLE
Add basic pagination to pledge table

### DIFF
--- a/static/bulma/sass/style.sass
+++ b/static/bulma/sass/style.sass
@@ -11,6 +11,10 @@ $light-grey: #E1E1DA
 $title-color: $dark
 $label-color: $dark
 
+$pagination-current-background-color: $yellow
+$pagination-current-border-color: $yellow
+$pagination-current-color: $dark
+
 // 3. Import the rest of Bulma
 @import "./node_modules/bulma/bulma"
 

--- a/strikecircle/templates/strikecircle/data_input_dashboard.html
+++ b/strikecircle/templates/strikecircle/data_input_dashboard.html
@@ -86,7 +86,40 @@
         {% endfor %}
     </div>
     {% endfor %}
+
+	{% if page_obj.paginator.num_pages > 1 %}
+		<nav class="pagination is-rounded" role="navigation" aria-label="pagination">
+			<ul class="pagination-list">
+				{% if page_obj.previous_page_number > 1 %}
+					<li><a class="pagination-link" href="?page=1">1</a></li>
+				{% endif %}
+
+				{% if ellipsis_start %}
+					<li><span class="pagination-ellipsis">&hellip;</span></li>
+				{% endif %}
+
+				{% if page_obj.has_previous %}
+					<li><a class="pagination-link" href="?page={{ page_obj.previous_page_number }}">{{ page_obj.previous_page_number }}</a></li>
+				{% endif %}
+
+				<li><a class="pagination-link is-current">{{ page_obj.number }}</a></li>
+
+				{% if page_obj.has_next %}
+					<li><a class='pagination-link' href="?page={{ page_obj.next_page_number }}">{{ page_obj.next_page_number }}</a></li>
+				{% endif %}
+
+				{% if ellipsis_end %}
+					<li><span class="pagination-ellipsis">&hellip;</span></li>
+				{% endif %}
+
+				{% if page_obj.next_page_number < page_obj.paginator.num_pages %}
+					<li><a class='pagination-link' href="?page={{ page_obj.paginator.num_pages }}">{{ page_obj.paginator.num_pages }}</a></li>
+				{% endif %}
+			</ul>
+		</nav>
+	{% endif %}
 </div>
+
 {% endblock content %}
 
 {% block extra_javascript %}


### PR DESCRIPTION
Resolves https://github.com/sunrisemovement/sunrise-strike-circles/issues/7.

Here's what it looks like with the number of results per page artificially set to 1 (rather than 20):
![pagination](https://user-images.githubusercontent.com/1022564/73576086-a2a04280-4447-11ea-904d-51c12e9ff1b7.gif)

Uses Django's built-in [Paginator](https://docs.djangoproject.com/en/3.0/ref/paginator/#django.core.paginator.Paginator) and Bulma's [pagination component](https://bulma.io/documentation/components/pagination/) set to our theme.